### PR TITLE
accommodate `make both` that uses a `bc` suffix instead of `cs`

### DIFF
--- a/plt-build.rkt
+++ b/plt-build.rkt
@@ -189,7 +189,13 @@
   (define racket-path
     (path->string (build-path trunk-dir "racket" "bin" "racket")))
   (define (raco-path cs?)
-    (path->string (build-path trunk-dir "racket" "bin" (if cs? "racocs" "raco"))))
+    (define (make-path suffix)
+      (path->string (build-path trunk-dir "racket" "bin" (string-append "raco" suffix))))
+    (define suffixed-p (make-path (if cs? "cs" "bc")))
+    (if (file-exists? suffixed-p)
+        suffixed-p
+        ;; Assume that the requested variant is the default one
+        (make-path "")))
   (define test-workers (make-job-queue (number-of-cpus)))
 
   (define pkgs-pths


### PR DESCRIPTION
Prepare for a change to the `racket` repo that makes CS the default.

Specifically, detect whether `racobc` or `raco` should be used as Racket BC and whether `racocs` or `raco` should be used as Racket CS.

The inference is not ideal, because if `raco` exists and no other variant is built, then `raco` will be used for all variants. This is probably good enough for a transition, though.