### PR TITLE
Fix file-history showing archived revisions as Pending

### DIFF
--- a/render.rkt
+++ b/render.rkt
@@ -1215,10 +1215,10 @@ in.}
   (define page-results
     (map (lambda (rev)
            (define pth (rev-analyze-path rev))
-           (define r (and (file-exists? pth) (read-cache* pth)))
+           (define r (read-cache* pth))
            (define log-pth (rev-log-path rev))
-           (define log (and r (file-exists? log-pth) (read-cache* log-pth)))
-           (define analyzed? (file-exists? (build-path (revision-dir rev) "analyzed")))
+           (define log (and r (read-cache* log-pth)))
+           (define analyzed? (and (read-cache* (build-path (revision-dir rev) "analyzed")) #t))
            (list rev (and r (rendering? r) r) log analyzed?))
          page-revs))
   (define history-url (format "/file-history/~a" file-path-str))

--- a/test-rendering.rkt
+++ b/test-rendering.rkt
@@ -19,6 +19,7 @@
          "path-utils.rkt"
          "cache.rkt"
          "analyze.rkt"
+         "make-archive-lib.rkt"
          "render.rkt")
 
 ;; --- Synthetic data setup ---
@@ -271,7 +272,32 @@
                                (dispatch-request (format "http://localhost/101/~a" test-file-path)))
                              (define body (response-body resp))
                              (check-regexp-match #rx"file-history" body)
-                             (check-regexp-match #rx"All results for this file" body))))))
+                             (check-regexp-match #rx"All results for this file" body))))
+
+    (test-case "file history page reads archived revisions correctly"
+      ;; Regression test: archived revisions used to show as "Pending" because
+      ;; show-file-history called file-exists? on the analyze and "analyzed"
+      ;; marker files, which fails after archiving deletes them. The fix is to
+      ;; use read-cache* which falls through to the archive.
+      (call-with-test-data (lambda ()
+                             ;; Archive revs 101, 102, 103 (101 is success,
+                             ;; 102 is failure, 103 is timeout). Rev 100 is
+                             ;; skipped because make-archive doesn't archive
+                             ;; multiples of 100.
+                             (make-archive 101)
+                             (make-archive 102)
+                             (make-archive 103)
+                             (define resp
+                               (dispatch-request
+                                (format "http://localhost/file-history/~a" test-file-path)))
+                             (check-equal? (response-code resp) 200)
+                             (define body (response-body resp))
+                             ;; Archived revisions must show their real status,
+                             ;; not "Pending".
+                             (check-regexp-match #rx"Success" body)
+                             (check-regexp-match #rx"Failure \\+ Stderr" body)
+                             (check-regexp-match #rx"Timeout" body)
+                             (check-false (regexp-match? #rx"Pending" body)))))))
 
 (module+ test
   (require rackunit/text-ui)


### PR DESCRIPTION
## Summary

\`show-file-history\` used \`file-exists?\` to check the analyze and \`analyzed\` marker files, which fails for archived revisions where those files have been moved into the archive db. The result was that all archived revisions on a file's history page displayed as \"Pending\" with no exit code or duration, e.g. on https://drdr.racket-lang.org/file-history/cs/pkgs/compiler-test/tests/compiler/ctool.rkt where 20 of 45 entries were wrongly marked Pending.

The fix uses \`read-cache*\` instead, which falls through to the archive db when the file isn't on disk. This matches what \`next-rev\` already does at render.rkt:83.

## Test plan

- [x] Added a regression test in test-rendering.rkt that archives synthetic revisions and verifies their statuses still appear correctly
- [x] Verified the new test fails without the fix and passes with it
- [x] All 15 tests in the rendering suite pass