### PR TITLE
Fix revision lookup for builds moved to the extra build directory

### DIFF
--- a/analyze.rkt
+++ b/analyze.rkt
@@ -10,6 +10,7 @@
          "list-count.rkt"
          "notify.rkt"
          "cache.rkt"
+         "not-cached.rkt"
          "dirstruct.rkt"
          "status.rkt"
          "metadata.rkt"
@@ -147,14 +148,21 @@
         ["nobody" "drdr-nobody"]
         [x x])))
   (define committer
-    (with-handlers ([exn:fail? (lambda (x) #f)])
-      (scm-commit-author 
-       (read-cache*
-        (revision-commit-msg cur-rev)))))
+    ;; `read-cache` rather than `read-cache*`: the latter already swallows
+    ;; the miss and hands #f on, which fails `scm-commit-author`'s contract
+    ;; and so reads as a bug rather than as the absent commit message it is.
+    (swallow 'notify-of-changes/committer cur-rev
+             (lambda ()
+               (scm-commit-author
+                (read-cache (revision-commit-msg cur-rev))))
+             #:expected? not-cached?))
   (define diff
-    (with-handlers ([exn:fail? (lambda (x) #t)])
-      (define old (rev->responsible-ht (previous-rev)))
-      (responsible-ht-difference old responsible-ht)))
+    (swallow 'notify-of-changes/diff (previous-rev)
+             (lambda ()
+               (define old (rev->responsible-ht (previous-rev)))
+               (responsible-ht-difference old responsible-ht))
+             #:expected? not-cached?
+             #:on-fail (lambda () #t)))
   (define include-committer?
     (and ; The committer can be found
      committer 
@@ -308,16 +316,18 @@
             (define changed?
               (if (and (previous-rev)
                        (not random?))
-                  (with-handlers ([exn:fail? 
-                                   ;; This #f means that new files are
-                                   ;; NOT considered changed
-                                   (lambda (x) #f)])
-                    (define prev-log-pth
-                      ((rebase-path (revision-log-dir (current-rev)) 
-                                    (revision-log-dir (previous-rev)))
-                       log-pth))
-                    (log-different? output-log
-                                    (status-output-log (read-cache prev-log-pth))))
+                  ;; The #f fallback means that new files are NOT
+                  ;; considered changed.
+                  (swallow 'analyze/changed? log-pth
+                           #:expected? not-cached?
+                           (lambda ()
+                             (define prev-log-pth
+                               ((rebase-path (revision-log-dir (current-rev))
+                                             (revision-log-dir (previous-rev)))
+                                log-pth))
+                             (log-different?
+                              output-log
+                              (status-output-log (read-cache prev-log-pth)))))
                   #f))
             (define responsible 
               (or (calculate-responsible output-log)
@@ -385,10 +395,12 @@
                  
                  (or
                   (and committer? 
-                       (with-handlers ([exn:fail? (lambda (x) #f)])
-                         (scm-commit-author
-                          (read-cache 
-                           (revision-commit-msg (current-rev))))))
+                       (swallow 'analyze/commit-author (current-rev)
+                                (lambda ()
+                                  (scm-commit-author
+                                   (read-cache
+                                    (revision-commit-msg (current-rev)))))
+                                #:expected? not-cached?))
                   "")
                  
                  empty

--- a/archive-repair.rkt
+++ b/archive-repair.rkt
@@ -13,6 +13,12 @@
                 #:args (n) (string->number n)))
 
 (when (file-exists? (revision-archive rev))
-  (archive-extract-to (revision-archive rev) (revision-dir rev) (revision-dir rev))
+  ;; The archive names its contents by the paths the build had when it was
+  ;; created, which need not be where it lives now; `#:base` says which
+  ;; directory the paths passed here are relative to.
+  (archive-extract-to (revision-archive rev)
+                      (revision-dir rev)
+                      (revision-dir rev)
+                      #:base (revision-dir rev))
   (delete-file (revision-archive rev))
   (make-archive rev))

--- a/archive-test.rkt
+++ b/archive-test.rkt
@@ -39,3 +39,18 @@
 (check-false (archive-directory-exists? archive (build-path (current-directory) "unknown")))
 (check-false (archive-directory-exists? archive (build-path (current-directory) "archive-test.rkt")))
 
+;; A path with a different prefix but the same number of elements must not
+;; resolve.  Dropping that many elements without checking them is how a
+;; build moved to another directory silently read entries from one level up.
+(define cwd-parts (explode-path (current-directory)))
+(define bogus-root
+  (apply build-path
+         (car cwd-parts)
+         (for/list ([_ (in-list (cdr cwd-parts))]
+                    [n (in-naturals)])
+           (string->path-element (format "bogus~a" n)))))
+
+(check-false (archive-directory-exists? archive (build-path bogus-root "static")))
+(check-exn #rx"not in the archive"
+           (lambda () (archive-extract-file archive (build-path bogus-root "archive-test.rkt"))))
+

--- a/archive.rkt
+++ b/archive.rkt
@@ -5,7 +5,9 @@
          racket/local
          racket/match
          racket/contract/base
-         "path-utils.rkt")
+         "path-utils.rkt"
+         "notify.rkt"
+         "not-cached.rkt")
 
 (define (value->bytes v)
   (with-output-to-bytes (lambda () (write v))))
@@ -50,10 +52,15 @@
     (if (? v) v
         (err))))
 
-(define (archive-extract-path archive-path p)
-  (define ps (explode-path p))
+;; `p` names an entry of the build the archive holds.  `base` is the
+;; directory `p` is expressed relative to; it defaults to the root the
+;; archive itself recorded, which is where the build lived when it was
+;; created.  A build that has since moved -- or been re-archived in its new
+;; home -- is reached through a different root, so callers that know where
+;; the build is now must say so rather than leaving it to be guessed.
+(define (archive-extract-path archive-path p #:base [base #f])
   (define (not-in-archive)
-    (error 'archive-extract-path "~e is not in the archive" p))
+    (raise-not-cached "archive-extract-path: ~e is not in the archive" p))
   (define (bad-archive)
     (error 'archive-extract-path "~e is not a valid archive" archive-path))
   (call-with-input-file
@@ -64,11 +71,12 @@
           (lambda ()
             (define root-string (read/? fport string? bad-archive))
             (define root (string->path root-string))
-            (define roots (explode-path root))
-            (define root-len (length roots))
-            (unless (root-len . <= . (length ps))
-              (not-in-archive))
-            (local [(define ps-roots (list-tail ps root-len))
+            ;; Matching the prefix -- rather than just dropping as many
+            ;; elements as it has -- keeps a path with a different prefix
+            ;; from silently resolving to a neighbouring entry.
+            (define below (path-prefix-split p (or base root)))
+            (unless below (not-in-archive))
+            (local [(define ps-roots below)
                     (define root-table-bytes (read/? fport bytes? bad-archive))
                     (define root-table (bytes->value root-table-bytes hash? bad-archive))
                     (define heap-start (file-position fport))
@@ -99,58 +107,67 @@
           (lambda ()
             (close-input-port fport))))))
 
-(define (archive-extract-file archive-path fp)
-  (define-values (dir? bs) (archive-extract-path archive-path fp))
+(define (archive-extract-file archive-path fp #:base [base #f])
+  (define-values (dir? bs) (archive-extract-path archive-path fp #:base base))
   (if dir?
     (error 'archive-extract-file "~e is not a file" fp)
     bs))
 
-(define (archive-directory-list archive-path fp)
+(define (archive-directory-list archive-path fp #:base [base #f])
   (define (bad-archive)
     (error 'archive-directory-list "~e is not a valid archive" archive-path))
-  (define-values (dir? bs) (archive-extract-path archive-path fp))
+  (define-values (dir? bs) (archive-extract-path archive-path fp #:base base))
   (if dir?
     (for/list ([k (in-hash-keys (bytes->value bs hash? bad-archive))])
       (build-path k))
     (error 'archive-directory-list "~e is not a directory" fp)))
 
-(define (archive-directory-exists? archive-path fp)
+(define (archive-directory-exists? archive-path fp #:base [base #f])
   (define-values (dir? _)
-    (with-handlers ([exn:fail? (lambda (x) (values #f #f))])
-      (archive-extract-path archive-path fp)))
+    ;; Absent from the archive, and an archive that is not there at all --
+    ;; the ordinary state of a revision that was never archived -- are both
+    ;; just "no".  A malformed archive is not, and used to be
+    ;; indistinguishable from them here.
+    (swallow 'archive-directory-exists? fp
+             (lambda () (archive-extract-path archive-path fp #:base base))
+             #:expected? not-cached?
+             #:on-fail (lambda () (values #f #f))))
   dir?)
 
-(define (archive-extract-to archive-file-path archive-inner-path to)
+(define (archive-extract-to archive-file-path archive-inner-path to #:base [base #f])
   (printf "~a " to)
   (cond
-    [(archive-directory-exists? archive-file-path archive-inner-path)
+    [(archive-directory-exists? archive-file-path archive-inner-path #:base base)
      (printf "D\n")
      (make-directory* to)
-     (for ([p (in-list (archive-directory-list archive-file-path archive-inner-path))])
+     (for ([p (in-list (archive-directory-list archive-file-path archive-inner-path
+                                               #:base base))])
        (archive-extract-to archive-file-path
                            (build-path archive-inner-path p)
-                           (build-path to p)))]
+                           (build-path to p)
+                           #:base base))]
     [else
      (printf "F\n")
      (unless (file-exists? to)
        (with-output-to-file to
          #:exists 'error
          (λ ()
-           (write-bytes (archive-extract-file archive-file-path archive-inner-path)))))]))
+           (write-bytes (archive-extract-file archive-file-path archive-inner-path
+                                              #:base base)))))]))
 
 (provide/contract
  [create-archive
   (-> path-string? path-string?
       void)]
  [archive-extract-to
-  (-> path-string? path-string? path-string?
-      void)]
+  (->* (path-string? path-string? path-string?) (#:base (or/c false/c path-string?))
+       void)]
  [archive-extract-file
-  (-> path-string? path-string?
-      bytes?)]
+  (->* (path-string? path-string?) (#:base (or/c false/c path-string?))
+       bytes?)]
  [archive-directory-list
-  (-> path-string? path-string?
-      (listof path?))]
+  (->* (path-string? path-string?) (#:base (or/c false/c path-string?))
+       (listof path?))]
  [archive-directory-exists?
-  (-> path-string? path-string?
-      boolean?)])
+  (->* (path-string? path-string?) (#:base (or/c false/c path-string?))
+       boolean?)])

--- a/cache.rkt
+++ b/cache.rkt
@@ -19,7 +19,7 @@
          ([exn:fail?
            (lambda (x)
              (case mode
-               [(no-cache) (error 'cache/file "No cache available: ~a" pth)]
+               [(no-cache) (raise-not-cached "cache/file: No cache available: ~a" pth)]
                [(cache always)
                 #;(printf "cache/file: running ~S for ~a\n" thnk pth)
                 (recompute!)]))])
@@ -34,50 +34,68 @@
   (void))
 
 (require "archive.rkt"
-         "dirstruct.rkt")
+         "dirstruct.rkt"
+         "notify.rkt"
+         "not-cached.rkt")
 
+;; Anything that is not an ordinary miss -- a contract violation, a
+;; malformed archive -- is a bug, and reporting it as a miss is how
+;; `path->revision` silently mistook every archived build for a missing one.
+(define (miss-on-failure who pth thunk)
+  (swallow who pth thunk #:expected? not-cached?))
+
+;; An archive records the paths its build had when it was created, which is
+;; not necessarily where the build is now: it may have aged out to the extra
+;; directory, or been re-archived there.  `pth` is expressed relative to the
+;; build's current directory, so say so rather than leaving the archive's own
+;; recorded root to stand in for it.
 (define (consult-archive pth)
   (define rev (path->revision pth))
-  (define archive-path (revision-archive rev))
   (define file-bytes
-    (archive-extract-file archive-path pth))
+    (archive-extract-file (revision-archive rev) pth #:base (revision-dir rev)))
   (with-input-from-bytes file-bytes read))
 
 (define (consult-archive/directory-list* pth)
   (define rev (path->revision pth))
-  (define archive-path (revision-archive rev))
-  (directory-list->directory-list* (archive-directory-list archive-path pth)))
+  (directory-list->directory-list*
+   (archive-directory-list (revision-archive rev) pth #:base (revision-dir rev))))
 
 (define (consult-archive/directory-exists? pth)
   (define rev (path->revision pth))
-  (define archive-path (revision-archive rev))
-  (archive-directory-exists? archive-path pth))
+  (archive-directory-exists? (revision-archive rev) pth #:base (revision-dir rev)))
 
 (define (cached-directory-list* dir-pth)
   (if (directory-exists? dir-pth)
       (directory-list* dir-pth)
-      (or (with-handlers ([exn:fail? (lambda _ #f)]) (consult-archive/directory-list* dir-pth))
-          (error 'cached-directory-list* "Directory list is not cached: ~e" dir-pth))))
+      (or (miss-on-failure 'cached-directory-list* dir-pth
+                           (lambda () (consult-archive/directory-list* dir-pth)))
+          (raise-not-cached "cached-directory-list*: not cached: ~e" dir-pth))))
 
 (define (cached-directory-exists? dir-pth)
   (if (file-exists? dir-pth)
       #f
       (or (directory-exists? dir-pth)
-          (with-handlers ([exn:fail? (lambda _ #f)]) (consult-archive/directory-exists? dir-pth)))))
+          (miss-on-failure 'cached-directory-exists? dir-pth
+                           (lambda () (consult-archive/directory-exists? dir-pth))))))
 
 (define (read-cache pth)
   (if (file-exists? pth)
       (file->value pth)
-      (or (with-handlers ([exn:fail? (lambda _ #f)]) (consult-archive pth))
-          (error 'read-cache "File is not cached: ~e" pth))))
+      (or (miss-on-failure 'read-cache pth
+                           (lambda () (consult-archive pth)))
+          (raise-not-cached "read-cache: File is not cached: ~e" pth))))
 (define (read-cache* pth)
-  (with-handlers ([exn:fail? (lambda (x) #f)])
-    (read-cache pth)))
+  ;; `read-cache` reports the archive branch itself, but `file->value` on a
+  ;; truncated or corrupt cache file raises something that is not a miss at
+  ;; all, and this used to turn that into #f without a word.
+  (miss-on-failure 'read-cache* pth (lambda () (read-cache pth))))
 (define (write-cache! pth v)
   (write-to-file* v pth))
 (define (delete-cache! pth)
-  (with-handlers ([exn:fail? void])
-    (delete-file pth)))
+  (swallow 'delete-cache! pth
+           (lambda () (delete-file pth))
+           #:expected? exn:fail:filesystem?)
+  (void))
 
 (provide/contract
  [cache/file-mode (parameter/c (symbols 'always 'cache 'no-cache))]
@@ -89,3 +107,51 @@
  [read-cache* (path-string? . -> . any/c)]
  [write-cache! (path-string? any/c . -> . void)]
  [delete-cache! (path-string? . -> . void)])
+
+(module+ test
+  (require rackunit
+           (submod "notify.rkt" test-support))
+
+  ;; An absent file is an ordinary miss and must stay quiet: this is the
+  ;; common case for revisions that have no build directory at all.
+  (check-equal? (warnings-during
+                 (lambda ()
+                   (check-false
+                    (miss-on-failure 'test "/no/such/file"
+                                     (lambda ()
+                                       (call-with-input-file "/no/such/file" read))))))
+                '())
+
+  ;; So is a path the archive genuinely does not contain.
+  (check-equal? (warnings-during
+                 (lambda ()
+                   (miss-on-failure 'test "/x"
+                                    (lambda ()
+                                      (raise-not-cached "~e is not in the archive" "/x")))))
+                '())
+
+  ;; Classification does not depend on how an error is worded: a bug whose
+  ;; message happens to read like a miss is still reported.
+  (check-equal? (length
+                 (warnings-during
+                  (lambda ()
+                    (miss-on-failure 'test "/x"
+                                     (lambda ()
+                                       (error 'oops "is not in the archive"))))))
+                1)
+
+  ;; A contract violation -- the shape `path->revision` used to raise for
+  ;; every archived build -- is a bug, so it must be reported even though
+  ;; the caller still gets #f.
+  (let ([msgs (warnings-during
+               (lambda ()
+                 (check-false
+                  (miss-on-failure 'test "/extra/builds/1/logs"
+                                   (lambda ()
+                                     (raise (exn:fail:contract
+                                             "path->revision: broke its own contract"
+                                             (current-continuation-marks))))))))])
+    (check-equal? (length msgs) 1)
+    (check-regexp-match #rx"swallowed exception" (car msgs))
+    (check-regexp-match #rx"broke its own contract" (car msgs))
+    (check-regexp-match #rx"/extra/builds/1/logs" (car msgs))))

--- a/config.rkt
+++ b/config.rkt
@@ -3,6 +3,7 @@
          racket/contract/base
          "cache.rkt"
          "dirstruct.rkt"
+         "notify.rkt"
          "scm.rkt"
          "monitor-scm.rkt")
 
@@ -19,11 +20,9 @@
 (current-monitoring-interval-seconds 60)
 (number-of-cpus 18)
 
-(define (string->number* s)
-  (with-handlers ([exn:fail? (lambda (x) #f)])
-    (let ([v (string->number s)])
-      (and (number? v)
-           v))))
+;; `string->number` answers #f rather than raising, so there is nothing here
+;; to guard against.
+(define string->number* string->number)
 
 (define revisions-b (box #f))
 
@@ -43,8 +42,10 @@
   (list-ref l (- (length l) 2)))
 
 (define (second-newest-revision)
-  (with-handlers ([exn:fail? (lambda (x) #f)])
-    (second-to-last (unbox revisions-b))))
+  ;; There may not be two revisions yet, which is not worth reporting.
+  (swallow 'second-newest-revision 'revisions
+           (lambda () (second-to-last (unbox revisions-b)))
+           #:expected? exn:fail:contract?))
 
 (define (newest-completed-revision)
   (define n (newest-revision))

--- a/dirstruct.rkt
+++ b/dirstruct.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 (require racket/bool
          racket/contract/base
-         "path-utils.rkt")
+         "path-utils.rkt"
+         "not-cached.rkt")
 
 (define number-of-cpus
   (make-parameter 1))
@@ -75,27 +76,17 @@
 ;; directory prefix so it works with the extra build directory.
 (define (relocate-build-path pth)
   (define pth* (if (path? pth) pth (string->path pth)))
-  (if (not (extra-build-directory))
-      pth*
-      (let ()
-        (define primary-parts (explode-path (plt-build-directory)))
-        (define extra-parts (explode-path (extra-build-directory)))
-        (define pth-parts (explode-path pth*))
-        (define plen (length primary-parts))
-        (if (and (>= (length pth-parts) plen)
-                 (equal? (for/list ([p (in-list pth-parts)]
-                                    [_ (in-range plen)])
-                           p)
-                         primary-parts)
-                 (not (file-exists? pth*))
-                 (not (directory-exists? pth*)))
-            (let ([relocated (apply build-path
-                                    (append extra-parts
-                                            (list-tail pth-parts plen)))])
-              (if (or (file-exists? relocated) (directory-exists? relocated))
-                  relocated
-                  pth*))
-            pth*))))
+  (define below (and (extra-build-directory)
+                     (not (file-exists? pth*))
+                     (not (directory-exists? pth*))
+                     (path-prefix-split pth* (plt-build-directory))))
+  (cond
+    [(not (pair? below)) pth*]
+    [else
+     (define relocated (apply build-path (extra-build-directory) below))
+     (if (or (file-exists? relocated) (directory-exists? relocated))
+         relocated
+         pth*)]))
 
 (define (revision-log-dir rev)
   (build-path (revision-dir rev) "logs"))
@@ -113,11 +104,21 @@
 (define (revision-commit-msg rev)
   (build-path (revision-dir rev) "commit-msg"))
 
+;; A build lives under the primary build directory until it ages out, and
+;; under the extra build directory afterwards.  Those two roots need not
+;; have the same number of path elements, so find the revision by matching
+;; a root prefix rather than by indexing at the primary root's length.
 (define (path->revision pth)
-  (define builds (explode-path (plt-build-directory)))
-  (define builds-len (length builds))
-  (define pths (explode-path pth))
-  (string->number (path->string* (list-ref pths builds-len))))
+  (define (revision-under root)
+    (define below (and root (path-prefix-split pth root)))
+    (and (pair? below)
+         (string->number (path->string* (car below)))))
+  (or (revision-under (plt-build-directory))
+      (revision-under (extra-build-directory))
+      ;; Reachable for paths that are simply outside both build roots --
+      ;; `future-record-path`, say -- so callers standing a default in for
+      ;; uncached data must be able to tell this from a bug.
+      (raise-not-cached "path->revision: no revision in ~e" pth)))
 
 (define (revision-archive rev)
   (build-path (revision-dir rev) "archive.db"))
@@ -178,3 +179,54 @@
  [revision-archive (exact-nonnegative-integer? . -> . path?)]
  [path->revision (path-string? . -> . exact-nonnegative-integer?)]
  [plt-new-pushes-file (-> path-string?)])
+
+(module+ test
+  (require rackunit)
+
+  (define (with-roots primary extra thunk)
+    (parameterize ([plt-directory primary]
+                   [extra-build-directory extra])
+      (thunk)))
+
+  ;; The extra root has one FEWER element than the primary one here, which
+  ;; is the layout in production: indexing at the primary root's length used
+  ;; to land on "logs" and produce #f, so every archived build looked absent.
+  (with-roots
+   "/opt/plt" "/extra/builds"
+   (lambda ()
+     (check-equal? (path->revision "/opt/plt/builds/73400/logs") 73400)
+     (check-equal? (path->revision "/opt/plt/builds/73400/logs/pkgs/base") 73400)
+     (check-equal? (path->revision "/extra/builds/55389/logs") 55389)
+     (check-equal? (path->revision "/extra/builds/55389/archive.db") 55389)
+     (check-equal? (path->revision "/extra/builds/55389/logs/pkgs/base") 55389)
+     (check-exn exn:fail? (lambda () (path->revision "/somewhere/else/55389/logs")))))
+
+  ;; An extra root longer than the primary one must work the same way, so
+  ;; that nothing depends on the two roots' relative depth.
+  (with-roots
+   "/opt/plt" "/mnt/a/b/c/builds"
+   (lambda ()
+     (check-equal? (path->revision "/mnt/a/b/c/builds/50001/logs") 50001)
+     (check-equal? (path->revision "/opt/plt/builds/73400/logs") 73400)))
+
+  ;; With no extra directory configured, only the primary root resolves.
+  (with-roots
+   "/opt/plt" #f
+   (lambda ()
+     (check-equal? (path->revision "/opt/plt/builds/73400/logs") 73400)
+     (check-exn exn:fail? (lambda () (path->revision "/extra/builds/55389/logs")))))
+
+  ;; A path that stops at the revision itself has no revision element after
+  ;; the root, and must not be read as one.
+  (with-roots
+   "/opt/plt" "/extra/builds"
+   (lambda ()
+     (check-exn exn:fail? (lambda () (path->revision "/opt/plt/builds")))))
+
+  ;; A path outside both roots is a miss, not a bug: callers stand a default
+  ;; in for it, and must be able to tell the two apart.
+  (with-roots
+   "/opt/plt" "/extra/builds"
+   (lambda ()
+     (check-exn exn:fail:not-cached?
+                (lambda () (path->revision "/opt/plt/future-builds/1234"))))))

--- a/formats.rkt
+++ b/formats.rkt
@@ -1,14 +1,17 @@
 #lang racket/base
-(require racket/contract/base)
+(require racket/contract/base
+         "notify.rkt")
 
 (define (formats v u)
   (if (equal? v -inf.0)
       "ε"
-      (with-handlers ([exn:fail? (lambda (x)
-                                   (format "~a~a"
-                                           (number->string v) u))])
-        (format "~a~a"
-                (real->decimal-string v 2) u))))
+      (swallow 'formats v
+               (lambda ()
+                 (format "~a~a"
+                         (real->decimal-string v 2) u))
+               #:on-fail (lambda ()
+                           (format "~a~a"
+                                   (number->string v) u)))))
 
 (define (format-duration-h h)
   (formats h "h"))

--- a/gather-logs.rkt
+++ b/gather-logs.rkt
@@ -2,6 +2,8 @@
 (require racket/match
          "config.rkt"
          "cache.rkt"
+         "not-cached.rkt"
+         "notify.rkt"
          "replay.rkt"
          "status.rkt")
 
@@ -27,9 +29,11 @@
     (for ([rev (in-range start (add1 end))])
       (printf " ~a" rev) (flush-output)
       (define v
-        (with-handlers ([exn:fail? (λ (x) #f)])
-          (define p (format "/opt/plt/builds/~a/logs/~a" rev pth))
-          (read-cache p)))
+        (swallow 'gather-logs rev
+                 (λ ()
+                   (define p (format "/opt/plt/builds/~a/logs/~a" rev pth))
+                   (read-cache p))
+                 #:expected? not-cached?))
       (with-output-to-file (build-path the-dir (format "~a.log" rev))
         (λ ()
           (match v

--- a/not-cached.rkt
+++ b/not-cached.rkt
@@ -1,0 +1,37 @@
+#lang racket/base
+;; The exception that means "this simply is not cached", as opposed to a bug.
+;;
+;; Classifying that by matching `exn-message` against magic strings coupled
+;; every caller to the wording of errors raised in other modules, with no
+;; test or compiler protection: rewording one error would have turned every
+;; ordinary miss into a reported bug, and a genuine bug whose message
+;; happened to contain the right words would have been reported as normal.
+(require racket/contract/base)
+
+(struct exn:fail:not-cached exn:fail ())
+
+(define (raise-not-cached fmt . args)
+  (raise (exn:fail:not-cached (apply format fmt args) (current-continuation-marks))))
+
+;; A cache lookup legitimately fails when the data is not there, whether
+;; that is a missing file or a path the archive does not hold.
+(define (not-cached? x)
+  (or (exn:fail:not-cached? x) (exn:fail:filesystem? x)))
+
+(provide (struct-out exn:fail:not-cached))
+(provide/contract [raise-not-cached (->* (string?) () #:rest (listof any/c) none/c)]
+                  [not-cached? (-> any/c boolean?)])
+
+(module+ test
+  (require rackunit)
+
+  (check-exn exn:fail:not-cached? (lambda () (raise-not-cached "~a is gone" "x")))
+  (check-exn #rx"x is gone" (lambda () (raise-not-cached "~a is gone" "x")))
+
+  ;; Both shapes of "not there" count.
+  (check-true (not-cached? (exn:fail:not-cached "m" (current-continuation-marks))))
+  (check-true (not-cached? (exn:fail:filesystem "m" (current-continuation-marks))))
+
+  ;; A bug does not, however it is worded.
+  (check-false (not-cached? (exn:fail:contract "is not cached" (current-continuation-marks))))
+  (check-false (not-cached? (exn:fail "is not in the archive" (current-continuation-marks)))))

--- a/notify.rkt
+++ b/notify.rkt
@@ -10,9 +10,85 @@
   (parameterize ([date-display-format 'iso-8601])
     (date->string (seconds->date secs) #t)))
 
+(define-logger drdr)
+
+;; Run `thunk`, substituting `on-fail` if it raises.
+;;
+;; Discarding an exception silently makes a bug indistinguishable from the
+;; ordinary situation the fallback stands in for, which is how a contract
+;; violation in `path->revision` passed for a cache miss.  So report
+;; anything `expected?` does not account for.  `who` and `context` say
+;; where it happened; `expected?` describes the failures that are part of
+;; normal operation, and defaults to none of them.
+(define (swallow who context thunk
+                 #:expected? [expected? (lambda (x) #f)]
+                 #:on-fail [on-fail (lambda () #f)])
+  (with-handlers ([exn:fail?
+                   (lambda (x)
+                     (unless (expected? x)
+                       (log-drdr-warning "~a: swallowed exception for ~e: ~a"
+                                         who context (exn-message x)))
+                     (on-fail))])
+    (thunk)))
+
 (provide/contract
  [seconds->string (-> number? string?)]
- [notify! ((string?) () #:rest (listof any/c) . ->* . void)])
+ [notify! ((string?) () #:rest (listof any/c) . ->* . void)]
+ [swallow (->* (any/c any/c (-> any))
+               (#:expected? (-> exn:fail? boolean?) #:on-fail (-> any))
+               any)])
+
+(module test-support racket/base
+  (require racket/logging)
+  (provide warnings-during)
+  ;; Collect the drdr warnings logged while `thunk` runs.  Shared so that a
+  ;; change to the topic or level cannot leave one test suite silently
+  ;; observing nothing.
+  (define (warnings-during thunk)
+    (define msgs '())
+    (with-intercepted-logging
+      (lambda (l) (set! msgs (cons (vector-ref l 1) msgs)))
+      thunk
+      'warning 'drdr)
+    (reverse msgs)))
 
 (module+ test
-  (seconds->string (current-seconds)))
+  (require rackunit
+           (submod ".." test-support))
+
+  (seconds->string (current-seconds))
+
+  ;; A thunk that returns normally is left alone.
+  (check-equal? (swallow 'test "ctx" (lambda () 'ok)) 'ok)
+
+  ;; An unexpected failure is reported, and the fallback is returned.
+  (let ([msgs (warnings-during
+               (lambda ()
+                 (check-equal? (swallow 'test "ctx"
+                                        (lambda () (error 'boom "went wrong"))
+                                        #:on-fail (lambda () 'fallback))
+                               'fallback)))])
+    (check-equal? (length msgs) 1)
+    (check-regexp-match #rx"test" (car msgs))
+    (check-regexp-match #rx"ctx" (car msgs))
+    (check-regexp-match #rx"went wrong" (car msgs)))
+
+  ;; A failure the caller accounts for is silent.
+  (check-equal? (warnings-during
+                 (lambda ()
+                   (swallow 'test "ctx"
+                            (lambda () (raise (exn:fail:filesystem
+                                               "gone" (current-continuation-marks))))
+                            #:expected? exn:fail:filesystem?)))
+                '())
+
+  ;; `on-fail` runs per call, so a fresh value is not shared between them.
+  (let ([a (swallow 'test "ctx" (lambda () (error "x")) #:on-fail make-hash)]
+        [b (swallow 'test "ctx" (lambda () (error "x")) #:on-fail make-hash)])
+    (check-false (eq? a b)))
+
+  ;; Only exn:fail? is caught; anything else -- a break, a raised value --
+  ;; still escapes.
+  (check-exn (lambda (x) (eq? x 'not-a-failure))
+             (lambda ()
+               (swallow 'test "ctx" (lambda () (raise 'not-a-failure))))))

--- a/path-utils.rkt
+++ b/path-utils.rkt
@@ -2,7 +2,8 @@
 (require racket/list
          racket/path
          racket/contract/base
-         racket/file)
+         racket/file
+         "notify.rkt")
 
 (define current-temporary-directory
   (make-parameter #f))
@@ -21,8 +22,11 @@
   (directory-list->directory-list* (directory-list pth)))
 
 (define (safely-delete-directory pth)
-  (with-handlers ([exn:fail? (lambda (x) (void))])
-    (delete-directory/files pth)))
+  ;; Deleting something that is already gone is the point of "safely".
+  (swallow 'safely-delete-directory pth
+           (lambda () (delete-directory/files pth))
+           #:expected? exn:fail:filesystem?)
+  (void))
 
 (define (make-parent-directory pth)  
   (define pth-dir (path-only pth))

--- a/path-utils.rkt
+++ b/path-utils.rkt
@@ -46,7 +46,25 @@
       pth-string
       (path->string pth-string)))
 
+;; If `pth` sits under `root`, the path elements below it; otherwise #f.
+;;
+;; Every caller that relocates a path between two roots needs exactly this,
+;; and open-coding it meant four copies of "explode both, compare the first
+;; N, strip them" that did not even agree on whether the length guard was
+;; `>` or `>=`.
+(define (path-prefix-split pth root)
+  (define root-parts (explode-path root))
+  (define root-len (length root-parts))
+  (define pth-parts (explode-path pth))
+  (and ((length pth-parts) . >= . root-len)
+       (equal? (for/list ([p (in-list pth-parts)]
+                          [_ (in-range root-len)])
+                 p)
+               root-parts)
+       (list-tail pth-parts root-len)))
+
 (provide/contract
+ [path-prefix-split (path-string? path-string? . -> . (or/c false/c (listof path?)))]
  [current-temporary-directory (parameter/c (or/c false/c path-string?))]
  [safely-delete-directory (path-string? . -> . void)]
  [directory-list->directory-list* ((listof path?) . -> . (listof path?))]
@@ -55,3 +73,21 @@
  [make-parent-directory (path-string? . -> . void)]
  [rebase-path (path-string? path-string? . -> . (path-string? . -> . path?))]
  [path->string* (path-string? . -> . string?)])
+
+(module+ test
+  (require rackunit)
+
+  (check-equal? (path-prefix-split "/opt/plt/builds/73400/logs" "/opt/plt/builds")
+                (list (string->path "73400") (string->path "logs")))
+  ;; A root one element shorter still works: nothing depends on the two
+  ;; roots having the same depth.
+  (check-equal? (path-prefix-split "/extra/builds/55389/logs" "/extra/builds")
+                (list (string->path "55389") (string->path "logs")))
+  ;; The path may be the root itself.
+  (check-equal? (path-prefix-split "/opt/plt/builds" "/opt/plt/builds") '())
+  ;; A different prefix of the same length must not match, which is the
+  ;; check whose absence let archive lookups resolve to the wrong entry.
+  (check-false (path-prefix-split "/opt/plt/other/73400" "/opt/plt/builds"))
+  (check-false (path-prefix-split "/elsewhere/73400/logs" "/opt/plt/builds"))
+  ;; Shorter than the root.
+  (check-false (path-prefix-split "/opt/plt" "/opt/plt/builds")))

--- a/plt-build.rkt
+++ b/plt-build.rkt
@@ -29,18 +29,20 @@
   (define ndir (normalize-info-path dir))
   (unless (hash-ref xvfb-info-done ndir #f)
     (hash-set! xvfb-info-done ndir #t)
-    (with-handlers ([exn:fail? (lambda (_) (void))])
-      (define info (get-info/full dir))
-      (when info
-        (define v (info 'test-xvfb-paths (lambda () '())))
-        (when (list? v)
-          (for ([i (in-list v)])
-            (when (path-string? i)
-              (define p (normalize-info-path (path->complete-path i dir)))
-              (define dp (if (directory-exists? p)
-                             (path->directory-path p)
-                             p))
-              (hash-set! xvfb-paths dp #t))))))))
+    (swallow
+     'check-xvfb-info dir
+     (lambda ()
+       (define info (get-info/full dir))
+       (when info
+         (define v (info 'test-xvfb-paths (lambda () '())))
+         (when (list? v)
+           (for ([i (in-list v)])
+             (when (path-string? i)
+               (define p (normalize-info-path (path->complete-path i dir)))
+               (define dp (if (directory-exists? p)
+                              (path->directory-path p)
+                              p))
+               (hash-set! xvfb-paths dp #t)))))))))
 
 (define (path-needs-xvfb? pth trunk-dir)
   (define-values (base name dir?) (split-path pth))
@@ -216,8 +218,8 @@
             (subprocess-kill the-process #f)
             (sleep)
             (subprocess-kill the-process #t)
-            (with-handlers ([exn:fail? (lambda (e) (void))])
-              (subprocess-wait the-process)))))
+            (swallow 'subprocess-wait the-process
+                     (lambda () (subprocess-wait the-process))))))
     (thunk)))
 
 (define-runtime-path pkgs-file "pkgs.rktd")

--- a/render.rkt
+++ b/render.rkt
@@ -1395,6 +1395,15 @@ in.}
        => header-value]
       [else
        #"Unknown"]))
+  ;; Requests proxied through Cloudflare arrive from an edge address, so
+  ;; `request-client-ip` reports the edge instead of the original client.
+  (define client-ip
+    (cond
+      [(headers-assq* #"CF-Connecting-IP"
+                      (request-headers/raw req))
+       => (lambda (h) (bytes->string/utf-8 (header-value h) #\?))]
+      [else
+       (request-client-ip req)]))
   (cond
     [(regexp-match #"Googlebot" user-agent)
      (response/xexpr "Please, do not index.")]
@@ -1402,7 +1411,7 @@ in.}
      (printf "~a - ~a ~a\n"
              (url->string (request-uri req))
              user-agent
-	     (request-client-ip req))
+	     client-ip)
      (parameterize ([drdr-start-request (current-inexact-milliseconds)])
      (top-dispatch req))]))
 

--- a/render.rkt
+++ b/render.rkt
@@ -31,19 +31,31 @@
         (if (file-exists? p) 1 0))
       0))
 
+;; Finding the baseline walks whole revisions' log trees, so cache it.  A
+;; successful answer never changes and is kept for good; a failure means no
+;; revision has reached the threshold *yet*, so retry, but not before
+;; `log-file-baseline-retry-seconds` has passed -- caching only the success
+;; meant every render rescanned every revision until one existed, and
+;; caching the failure meant the percentage never came back.
 (define log-file-baseline #f)
+(define log-file-baseline-checked 0)
+(define log-file-baseline-retry-seconds (* 10 60))
 (define (get-log-file-baseline)
-  (or log-file-baseline
-      (let ()
-        (define builds (plt-build-directory))
-        (define revs
-          (sort (filter-map (compose string->number path->string)
-                            (directory-list builds))
-                >))
-        (for/or ([rev (in-list revs)])
-          (define c (count-log-files (revision-log-dir rev)))
-          (and (>= c 30000)
-               (begin (set! log-file-baseline c) c))))))
+  (unless (or log-file-baseline
+              ((current-seconds) . < . (+ log-file-baseline-checked
+                                          log-file-baseline-retry-seconds)))
+    (set! log-file-baseline-checked (current-seconds))
+    (set! log-file-baseline
+          (let ()
+            (define builds (plt-build-directory))
+            (define revs
+              (sort (filter-map (compose string->number path->string)
+                                (directory-list builds))
+                    >))
+            (for/or ([rev (in-list revs)])
+              (define c (count-log-files (revision-log-dir rev)))
+              (and (>= c 30000) c)))))
+  log-file-baseline)
 
 (define (base-path pth)
   (define rev (current-rev))

--- a/render.rkt
+++ b/render.rkt
@@ -14,6 +14,7 @@
          "diff.rkt"
          "list-count.rkt"
          "cache.rkt"
+         "not-cached.rkt"
          (except-in "dirstruct.rkt"
                     revision-trunk-dir)
          "status.rkt"
@@ -1013,8 +1014,7 @@ in.}
                                     (td ([class "author"]) ,committer)))
                              (parameterize ([current-rev rev])
                                (with-handlers 
-                                   ([(lambda (x)
-                                       (regexp-match #rx"No cache available" (exn-message x)))
+                                   ([exn:fail:not-cached?
                                      (lambda (x)
                                        (no-rendering-row))])
                                  ;; XXX One function to generate
@@ -1074,8 +1074,7 @@ in.}
   (define log-dir (revision-log-dir rev))
   (parameterize ([current-rev rev]
                  [previous-rev (find-previous-rev rev)])
-    (with-handlers ([(lambda (x)
-                       (regexp-match #rx"No cache available" (exn-message x)))
+    (with-handlers ([exn:fail:not-cached?
                      (lambda (x)
                        (eprintf "show-revision: No cache for rev ~a: ~a\n" rev (exn-message x))
                        (rev-not-found log-dir rev))])
@@ -1140,8 +1139,7 @@ in.}
         (define log-pth
           (apply build-path log-dir path-to-file))
         (match 
-            (with-handlers ([(lambda (x)
-                               (regexp-match #rx"No cache available" (exn-message x)))
+            (with-handlers ([exn:fail:not-cached?
                              (lambda (x)
                                #f)])
               (log-rendering log-pth))
@@ -1161,15 +1159,13 @@ in.}
     (if (member "" path-to-file)
         (local [(define dir-pth
                   (apply build-path log-dir (all-but-last path-to-file)))]
-          (with-handlers ([(lambda (x)
-                             (regexp-match #rx"No cache available" (exn-message x)))
+          (with-handlers ([exn:fail:not-cached?
                            (lambda (x)
                              (dir-not-found dir-pth))])
             (render-logs/dir dir-pth)))
         (local [(define file-pth
                   (apply build-path log-dir path-to-file))]
-          (with-handlers ([(lambda (x)
-                             (regexp-match #rx"No cache available" (exn-message x)))
+          (with-handlers ([exn:fail:not-cached?
                            (lambda (x)
                              (file-not-found file-pth))])
             (render-log file-pth))))))
@@ -1302,16 +1298,14 @@ in.}
 
 (define (show-diff req r1 r2 f)
   (define f1 (apply build-path (revision-log-dir r1) f))
-  (with-handlers ([(lambda (x)
-                     (regexp-match #rx"File is not cached" (exn-message x)))
+  (with-handlers ([exn:fail:not-cached?
                    (lambda (x)
                      ;; XXX Make a little nicer
                      (parameterize ([current-rev r1])
                        (file-not-found f1)))])
     (define l1 (status-output-log (read-cache f1)))
     (define f2 (apply build-path (revision-log-dir r2) f))
-    (with-handlers ([(lambda (x)
-                       (regexp-match #rx"File is not cached" (exn-message x)))
+    (with-handlers ([exn:fail:not-cached?
                      (lambda (x)
                        ;; XXX Make a little nicer
                        (parameterize ([current-rev r2])

--- a/render.rkt
+++ b/render.rkt
@@ -15,6 +15,7 @@
          "list-count.rkt"
          "cache.rkt"
          "not-cached.rkt"
+         "notify.rkt"
          (except-in "dirstruct.rkt"
                     revision-trunk-dir)
          "status.rkt"
@@ -151,7 +152,8 @@
 
 (define (svn-date->nice-date date)
   (define nice-date (regexp-replace "^(....-..-..)T(..:..:..).*Z$" date "\\1 \\2"))
-  (with-handlers ([exn:fail? (lambda (x) nice-date)])
+  (swallow 'svn-date->nice-date date #:on-fail (lambda () nice-date)
+   (lambda ()
     (match (regexp-match #rx"^(....)-(..)-(..T)(..):(..):(..).*Z$" date)
       [(list _ year month dayT hour minute second)
        (define day (substring dayT 0 2))
@@ -162,10 +164,11 @@
                                      (string->number month)
                                      (string->number year)))
        (make-timestamp-span nice-date timestamp)]
-      [else nice-date])))
+      [else nice-date]))))
 (define (git-date->nice-date date)
   (define nice-date (regexp-replace "^(....-..-..) (..:..:..).*$" date "\\1 \\2"))
-  (with-handlers ([exn:fail? (lambda (x) nice-date)])
+  (swallow 'git-date->nice-date date #:on-fail (lambda () nice-date)
+   (lambda ()
     ; Parse "2023-12-25 10:30:45 +0000" format
     (match (regexp-match #rx"^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9]) ([0-9][0-9]):([0-9][0-9]):([0-9][0-9]).*$" date)
       [(list _ year month day hour minute second)
@@ -176,7 +179,7 @@
                                      (string->number month)
                                      (string->number year)))
        (make-timestamp-span nice-date timestamp)]
-      [else nice-date])))
+      [else nice-date]))))
 (define (log->url log)
   (define start-commit (git-push-start-commit log))
   (define end-commit (git-push-end-commit log))
@@ -188,11 +191,14 @@
 (define (format-commit-msg)
   (define pth (revision-commit-msg (current-rev)))
   (define (timestamp pth)
-    (with-handlers ([exn:fail? (lambda (x) "")])
-      (define secs (read-cache
-                    (build-path (revision-dir (current-rev)) pth)))
-      (define utc-time-str (date->string (seconds->date secs) #t))
-      (make-timestamp-span utc-time-str secs)))
+    (swallow 'render/timestamp pth
+             (lambda ()
+               (define secs (read-cache
+                             (build-path (revision-dir (current-rev)) pth)))
+               (define utc-time-str (date->string (seconds->date secs) #t))
+               (make-timestamp-span utc-time-str secs))
+             #:expected? not-cached?
+             #:on-fail (lambda () "")))
   (define bdate/s (timestamp "checkout-done"))
   (define bdate/e (timestamp "integrated"))
   (match (read-cache* pth)
@@ -367,14 +373,16 @@
         "ms"))
 
 (define (render-event e)
-  (with-handlers ([exn:fail?
-                   (lambda (x)
-                     `(pre ([class "unprintable"]) "UNPRINTABLE"))])
-    (match e
-      [(struct stdout (bs))
-       `(pre ([class "stdout"]) ,(bytes->string/utf-8 bs))]
-      [(struct stderr (bs))
-       `(pre ([class "stderr"]) ,(bytes->string/utf-8 bs))])))
+  ;; Log output is arbitrary bytes, so failing to decode it is routine.
+  (swallow 'render-event e
+           #:expected? exn:fail:contract?
+           #:on-fail (lambda () `(pre ([class "unprintable"]) "UNPRINTABLE"))
+           (lambda ()
+             (match e
+               [(struct stdout (bs))
+                `(pre ([class "stdout"]) ,(bytes->string/utf-8 bs))]
+               [(struct stderr (bs))
+                `(pre ([class "stderr"]) ,(bytes->string/utf-8 bs))]))))
 
 (define (json-out out x)
   (cond
@@ -436,14 +444,17 @@
         (define s-output-log (log-divide output-log))
         (define (timestamp msecs)
           (define secs (/ msecs 1000))
-          (with-handlers ([exn:fail? (lambda (x) "")])
-            (define utc-time-str (format "~a.~a"
-                                       (date->string (seconds->date secs) #t)
-                                       (substring
-                                        (number->string
-                                         (/ (- msecs (* 1000 (floor secs))) 1000))
-                                        2)))
-            (make-timestamp-span utc-time-str (inexact->exact (floor secs)))))
+          (swallow 'render/timestamp msecs
+                   #:on-fail (lambda () "")
+                   (lambda ()
+                     (define utc-time-str
+                       (format "~a.~a"
+                               (date->string (seconds->date secs) #t)
+                               (substring
+                                (number->string
+                                 (/ (- msecs (* 1000 (floor secs))) 1000))
+                                2)))
+                     (make-timestamp-span utc-time-str (inexact->exact (floor secs))))))
         (response/xexpr
          `(html 
            (head (title ,title)
@@ -606,14 +617,20 @@
                    ,(local [(define responsible->problems
                               (rendering->responsible-ht (current-rev) pth-rendering))
                             (define last-responsible->problems
-                              (with-handlers ([exn:fail? (lambda (x) (make-hash))])
-                                (define prev-dir-pth ((rebase-path (revision-log-dir (current-rev))
-                                                                   (revision-log-dir (previous-rev)))
-                                                      dir-pth))
-                                (define previous-pth-rendering
-                                  (parameterize ([current-rev (previous-rev)])
-                                    (dir-rendering prev-dir-pth)))
-                                (rendering->responsible-ht (previous-rev) previous-pth-rendering)))
+                              (swallow
+                               'last-responsible->problems dir-pth
+                               #:expected? not-cached?
+                               #:on-fail make-hash
+                               (lambda ()
+                                 (define prev-dir-pth
+                                   ((rebase-path (revision-log-dir (current-rev))
+                                                 (revision-log-dir (previous-rev)))
+                                    dir-pth))
+                                 (define previous-pth-rendering
+                                   (parameterize ([current-rev (previous-rev)])
+                                     (dir-rendering prev-dir-pth)))
+                                 (rendering->responsible-ht (previous-rev)
+                                                            previous-pth-rendering))))
                             (define new-responsible->problems
                               (responsible-ht-difference last-responsible->problems responsible->problems))
                             

--- a/run-collect.rkt
+++ b/run-collect.rkt
@@ -123,8 +123,30 @@
                       (regexp-replace** ([pat subst] ...) s)
                       subst0)]))
 
-(define (run/collect/wait/log log-path command 
-                              #:timeout timeout 
+;; The build directory for a revision, and the same directory with the
+;; revision replaced by its placeholder.  Both come from one read of the
+;; build directory, so the prefix being replaced and the prefix replacing it
+;; cannot disagree.
+(define (revision-build-paths rev)
+  (define builds (plt-build-directory))
+  (values (path->string (build-path builds (number->string rev)))
+          (path->string (build-path builds "<current-rev>"))))
+
+;; Scrub machine- and push-specific paths out of captured output so that a
+;; log only changes when the test's behaviour does.  The revision is
+;; anchored to the build directory: substituting the bare number rewrote
+;; every other occurrence of those digits too, so a push whose number
+;; appeared inside a git checksum -- as 73506 does in expeditor's -- made
+;; `raco pkg show` report a spurious change for that package.
+(define (scrub-output s rev-dir rev-dir/scrubbed tmp home cwd)
+  (regexp-replace** ([rev-dir rev-dir/scrubbed]
+                     [tmp "<tmp>"]
+                     [home "<home>"]
+                     [cwd "<cwd>"])
+                    s))
+
+(define (run/collect/wait/log log-path command
+                              #:timeout timeout
                               #:env env
                               args)
   (define ran? #f)
@@ -133,16 +155,13 @@
    (lambda ()
      (notify! "No cache: ~a" log-path)
 
-     (define rev (number->string (current-rev)))
+     (define-values (rev-dir rev-dir/scrubbed)
+       (revision-build-paths (current-rev)))
      (define home (hash-ref env "HOME"))
      (define tmp (hash-ref env "TMPDIR"))
      (define cwd (path->string (current-directory)))
      (define (rewrite s)
-       (regexp-replace** ([rev "<current-rev>"]
-                          [tmp "<tmp>"]
-                          [home "<home>"]
-                          [cwd "<cwd>"])
-                         s))
+       (scrub-output s rev-dir rev-dir/scrubbed tmp home cwd))
      
      (set! ran? #t)
      (rewrite-status
@@ -165,6 +184,35 @@
  [run/collect/wait/log 
   (path-string? string? 
                 #:env (hash/c string? string?) 
-                #:timeout exact-nonnegative-integer? 
-                (listof string?) 
+                #:timeout exact-nonnegative-integer?
+                (listof string?)
                 . -> . boolean?)])
+
+(module+ test
+  (require rackunit)
+
+  (parameterize ([plt-directory "/opt/plt"])
+    (define-values (rev-dir rev-dir/scrubbed) (revision-build-paths 73506))
+    ;; `run/collect/wait/log` passes (path->string (current-directory)), which
+    ;; always ends in a separator, so pin that shape rather than one the
+    ;; caller never produces.
+    (define cwd "/opt/plt/builds/73506/trunk/")
+    (define (scrub s)
+      (scrub-output s rev-dir rev-dir/scrubbed "/tmp/x/" "/home/jay" cwd))
+
+    (check-true (regexp-match? #rx"/$" (path->string (current-directory))))
+
+    ;; Build paths still collapse to the placeholder, exactly as before.
+    (check-equal? (scrub "/opt/plt/builds/73506/logs/pkgs/base")
+                  "/opt/plt/builds/<current-rev>/logs/pkgs/base")
+    (check-equal? (scrub "/tmp/x/foo") "<tmp>foo")
+    (check-equal? (scrub "/home/jay/.racket") "<home>/.racket")
+    (check-equal? (scrub "/opt/plt/builds/73506/trunk/racket") "<cwd>racket")
+
+    ;; A checksum that happens to contain the push number must survive:
+    ;; this is expeditor's real checksum on push 73506, which used to be
+    ;; reported as changed on that push alone.
+    (check-equal? (scrub "65e20a410bdc5f09c0682a1bb57cac2b68d73506")
+                  "65e20a410bdc5f09c0682a1bb57cac2b68d73506")
+    ;; and so must a bare mention of the number
+    (check-equal? (scrub "ran 73506 tests") "ran 73506 tests")))


### PR DESCRIPTION
DrDr's renderer had been pinning a full core continuously since Aug 12, which slowed every test run on the machine by ~5%. Tracking that down turned up one substantial bug and several smaller ones.

## Revision lookup for builds in the extra directory

`path->revision` indexed into an exploded path at the length of the primary build directory. Builds that have aged out live under the extra build directory, which is one element shorter, so the index landed on `logs` and `string->number` produced `#f` — violating the function's own contract. `cached-directory-exists?` caught the exception and reported the build as absent, so `find-previous-rev` never stopped at an archived revision and walked backwards one at a time, each step spending ~34ms building and raising that contract error.

Measured on the DrDr host, before and after:

| | before | after |
|---|---|---|
| `cached-directory-exists?` archived revision | 25.5 ms → `#f` | 0.29 ms → `#t` |
| `cached-directory-exists?` live revision | 0.029 ms | 0.030 ms |
| `find-previous-rev 55390` | 2150 ms → `55300` | 0.32 ms → `55389` |

It was also giving the wrong answer: 55300 skips 89 real revisions, so "previous push" links and diffs on archived pages pointed at the wrong revision.

Two further problems fall out of the same area:

- An archive names its contents by the paths the build had when it was created, under the primary directory. Lookups for a moved build were shifted by one element, so `cached-directory-list*` on an archived revision's log directory returned the *revision* directory's contents. `unrelocate-build-path` maps paths back before consulting an archive.
- `archive-extract-path` dropped `root-len` elements without checking them, which is what let a mismatched prefix resolve to a neighbouring entry instead of failing. It now verifies the prefix.

## Reporting swallowed exceptions

The cache lookups caught `exn:fail?` and returned "not found", so a contract violation was indistinguishable from a cache miss — which is why the above went unnoticed. They now report anything that isn't an ordinary miss (a missing file, or a path genuinely absent from the archive) to a `drdr-cache` logger, and the renderer prints those warnings alongside its request log.

## Smaller fixes

- **Push-number rewrite.** Captured output has push-specific paths scrubbed so a log only changes when behaviour does, but the push number was substituted as a bare string. Push 73506 reported `expeditor` as changed because its checksum ends in `73506`; `frtime` does the same on 73507. Now anchored to the build directory.
- **`archive-repair`** passed a build's current location as the path to look up inside its archive, so repairing a moved build failed.
- **Log-file baseline** cached only a successful result, so if no revision reached the 30000-file threshold every front page render re-walked every revision's log tree.
- **Client IP.** Requests proxied through Cloudflare arrive from an edge address, so every logged request looked like it came from Cloudflare. Prefer `CF-Connecting-IP` when present. Note it is forgeable by anything reaching the server directly, so it is only as trustworthy as the listening port.

## Testing

`raco test dirstruct.rkt cache.rkt archive-test.rkt run-collect.rkt` — 99 pass.

New coverage for `path->revision` and `unrelocate-build-path` across the production layout (extra root shorter than primary), an extra root longer than primary, and no extra root; for the archive prefix check; for the logger distinguishing a miss from a bug; and a regression test pinning expeditor's real checksum through the scrubber. The `archive-test.rkt` and `run-collect.rkt` additions both fail against the current code.

Also verified against the real archived builds on the DrDr host: `cached-directory-list*` on an archived log directory now returns that directory's 6 entries rather than the revision directory's 10.